### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-test.yaml
+++ b/.github/workflows/release-test.yaml
@@ -1,4 +1,6 @@
 name: DataTest
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/Rollphes/genshin-manager/security/code-scanning/5](https://github.com/Rollphes/genshin-manager/security/code-scanning/5)

To fix the problem, add a `permissions` block at the top level of the workflow file (just after the `name:` and before `on:`), or at the job level for each job. Since all jobs in this workflow only need to read repository contents, the minimal required permission is `contents: read`. Adding this block at the workflow level will apply it to all jobs, ensuring the `GITHUB_TOKEN` is limited to read-only access to repository contents. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
