### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-test.yaml
+++ b/.github/workflows/release-test.yaml
@@ -1,4 +1,6 @@
 name: DataTest
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/Rollphes/genshin-manager/security/code-scanning/6](https://github.com/Rollphes/genshin-manager/security/code-scanning/6)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the minimal required permissions for the jobs. Since all jobs only need to read the repository contents (for checkout and running tests), you should set `contents: read`. This can be done at the workflow level (top-level, before `jobs:`), which will apply to all jobs unless overridden. No additional imports or definitions are needed; simply add the following block:

```yaml
permissions:
  contents: read
```

This should be placed after the `name:` and before the `on:` block in `.github/workflows/release-test.yaml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
