### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-test.yaml
+++ b/.github/workflows/release-test.yaml
@@ -1,4 +1,6 @@
 name: DataTest
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/Rollphes/genshin-manager/security/code-scanning/7](https://github.com/Rollphes/genshin-manager/security/code-scanning/7)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the jobs in this workflow only check out code and run local commands (install, build, test), they only need `contents: read` permission. The best way to do this is to add a `permissions:` block at the top level of the workflow file (just after the `name:` and before `on:`), so it applies to all jobs. No changes to the jobs themselves are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
