### PR TITLE
ci(cd): migrate npm auth to OIDC trusted publishing

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Publish to NPM
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Generate release notes
         id: generate-notes


### PR DESCRIPTION
Remove legacy NPM_TOKEN secret usage and switch to OIDC-based authentication for npm publishing. This addresses the npm classic token deprecation announced on 2025-12-09.

Requires npm trusted publisher configuration for the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDワークフローのNPM公開ステップを更新しました。

**注記:** このリリースではユーザーに直接影響する機能追加やバグ修正はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->