### PR TITLE
feat(client): support partial match in getXxxByName methods

### DIFF
--- a/src/client/AssetCacheManager.ts
+++ b/src/client/AssetCacheManager.ts
@@ -292,11 +292,15 @@ export abstract class AssetCacheManager<
       .filter(([, obj]) => {
         if (!obj || typeof obj !== 'object') return false
         const objRecord = obj as JsonObject
+        const lowerText = text.toLowerCase()
         return Object.keys(objRecord).some((jsonKey) => {
           if (/TextMapHash/g.exec(jsonKey)) {
             const value = objRecord[jsonKey]
-            if (typeof value === 'number')
-              return this._cachedTextMap.get(value) === text
+            if (typeof value === 'number') {
+              const textMapValue = this._cachedTextMap.get(value)
+              if (textMapValue)
+                return textMapValue.toLowerCase().includes(lowerText)
+            }
           }
           return false
         })

--- a/src/models/character/CharacterInfo.test.ts
+++ b/src/models/character/CharacterInfo.test.ts
@@ -28,9 +28,14 @@ describe('CharacterInfo', () => {
       expect(ids).toEqual([10000002])
     })
 
-    it('should return empty array for partial name', () => {
+    it('should get character ID by partial name', () => {
       const ids = CharacterInfo.getCharacterIdByName('Ayaka')
-      expect(ids).toEqual([])
+      expect(ids).toContain(10000002)
+    })
+
+    it('should get character ID by case-insensitive name', () => {
+      const ids = CharacterInfo.getCharacterIdByName('kamisato ayaka')
+      expect(ids).toContain(10000002)
     })
 
     it('should get traveler skill depot IDs', () => {

--- a/src/types/enkaNetwork/EnkaTypes.ts
+++ b/src/types/enkaNetwork/EnkaTypes.ts
@@ -207,7 +207,7 @@ export interface APIAvatarInfo {
   propMap: Record<number, APIPropMap>
   /**
    * List of Constellation IDs
-   * @warn There is no data if 0 Constellation
+   * @warning There is no data if 0 Constellation
    */
   talentIdList?: number[]
   /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -133,20 +133,20 @@ export interface ClientOption {
   logLevel?: LogLevel
   /**
    * auto fetch latest assets by cron
-   * @warn If this option is `undefined`, asset updates and initial setup are not executed
+   * @warning If this option is `undefined`, asset updates and initial setup are not executed
    * @default '0 0 0 * * 3' // minute hour day-of-month month day-of-week
    * @see https://crontab.guru/
    */
   autoFetchLatestAssetsByCron: string | undefined
   /**
    * Automatically re-download the textMap if it has not been downloaded or if there is an error in the json format
-   * @warn If `autoFetchLatestAssetsByCron` is `undefined`, this option will be ignored
+   * @warning If `autoFetchLatestAssetsByCron` is `undefined`, this option will be ignored
    * @default true
    */
   autoFixTextMap: boolean
   /**
    * Automatically fix the ExcelBin if it has not been downloaded or if there is an error in the json format
-   * @warn If `autoFetchLatestAssetsByCron` is `undefined`, this option will be ignored
+   * @warning If `autoFetchLatestAssetsByCron` is `undefined`, this option will be ignored
    * @default true
    */
   autoFixExcelBin: boolean


### PR DESCRIPTION
## Summary

Add partial/fuzzy match support to `getXxxByName` methods across the codebase.

- Case-insensitive matching
- Partial string matching (contains)

## Changes

| Category | Changes |
|----------|---------|
| client | Update `_searchIdInExcelBinOutByText` to support partial match and case-insensitive search |
| test | Add partial match and case-insensitive tests for `CharacterInfo.getCharacterIdByName` |
| style | Replace `@warn` with `@warning` in JSDoc |

## Affected Methods

All methods that use `_searchIdInExcelBinOutByText` internally:

- `Weapon.getWeaponIdByName()`
- `WeaponInfo.getWeaponIdByName()`
- `Character.getCharacterIdByName()`
- `CharacterInfo.getCharacterIdByName()`
- `Material.getMaterialIdByName()`

## Breaking Changes

The default behavior of `getXxxByName` methods has changed from exact match to partial match.

```typescript
// Before
Weapon.getWeaponIdByName('Mistsplitter')         // Returns []
Weapon.getWeaponIdByName('Mistsplitter Reforged') // Returns [11509]

// After
Weapon.getWeaponIdByName('Mistsplitter')         // Returns [11509]
Weapon.getWeaponIdByName('mistsplitter')         // Returns [11509] (case-insensitive)
Weapon.getWeaponIdByName('Mistsplitter Reforged') // Returns [11509]
```

## Test Plan

- [x] `npm run lint:fix` passes
- [x] `npm run test` passes (1730 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character and asset search now supports case-insensitive substring matching. Find results by typing partial names regardless of capitalization, improving search flexibility.

* **Tests**
  * Updated test coverage to validate case-insensitive and partial name matching behavior.

* **Documentation**
  * Enhanced documentation annotations for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->